### PR TITLE
C header files must define `typedef xxxOpaque`, only when the class ha…

### DIFF
--- a/macroslib/tests/expectations/c_self_type.cpp
+++ b/macroslib/tests/expectations/c_self_type.cpp
@@ -1,0 +1,43 @@
+r##"#pragma once
+
+//for (u)intX_t types
+#include <stdint.h>
+
+#ifdef __cplusplus
+static_assert(sizeof(uintptr_t) == sizeof(uint8_t) * 8,
+   "our conversion usize <-> uintptr_t is wrong");
+extern "C" {
+#endif
+
+
+    typedef struct WithSelfTypeOpaque WithSelfTypeOpaque;
+
+    WithSelfTypeOpaque *WithSelfType_new();
+
+    void WithSelfType_do_something(const WithSelfTypeOpaque * const self);
+
+    void WithSelfType_delete(const WithSelfTypeOpaque *self);
+
+#ifdef __cplusplus
+}
+#endif
+"##;
+
+
+r##"#pragma once
+
+//for (u)intX_t types
+#include <stdint.h>
+
+#ifdef __cplusplus
+static_assert(sizeof(uintptr_t) == sizeof(uint8_t) * 8,
+   "our conversion usize <-> uintptr_t is wrong");
+extern "C" {
+#endif
+
+    void WithoutSelfType_do_nothing();
+
+#ifdef __cplusplus
+}
+#endif
+"##;

--- a/macroslib/tests/expectations/c_self_type.rs
+++ b/macroslib/tests/expectations/c_self_type.rs
@@ -1,0 +1,17 @@
+
+// With self_type, C header must contain 'typedef WithSelfTypeOpaque'.
+foreigner_class!(
+    class WithSelfType {
+        self_type WithSelfType;
+        constructor WithSelfType::new() -> WithSelfType;
+        fn WithSelfType::do_something(&self);
+    }
+);
+
+// With no self_type, C header should not contain 'typedef WithoutSelfTypeOpaque'.
+foreign_class!(
+    class WithoutSelfType {
+        fn WithoutSelfType::do_nothing();
+    }
+);
+

--- a/macroslib/tests/expectations/cenum.cpp
+++ b/macroslib/tests/expectations/cenum.cpp
@@ -50,9 +50,6 @@ static_assert(sizeof(uintptr_t) == sizeof(uint8_t) * 8,
 extern "C" {
 #endif
 
-    typedef struct BooOpaque BooOpaque;
-
-
     uint32_t Boo_return_is_enum();
 
     void Boo_param_is_enum(uint32_t e);

--- a/macroslib/tests/expectations/tests.list
+++ b/macroslib/tests/expectations/tests.list
@@ -67,3 +67,4 @@ cpp_ret_opt_qstring
 callback_in_callback_args
 fenum
 cenum
+c_self_type


### PR DESCRIPTION
…s a `self_type`.

Without any `self_type`, the `typedef xxxOpaque` is useless.
Fixed cenum test case, which has no `self_type`.
Added a C test case, testing both cases (with and without `self_type`).

fixes #431