### PR TITLE
More typos

### DIFF
--- a/macroslib/src/cpp/cpp_code.rs
+++ b/macroslib/src/cpp/cpp_code.rs
@@ -177,9 +177,9 @@ pub(in crate::cpp) fn cpp_list_required_includes(
     let mut includes = Vec::<SmolStr>::with_capacity(methods.len());
     for m in methods {
         for p in &mut m.input {
-            includes.extend(mem::take(&mut p.provides_by_module).into_iter());
+            includes.extend(mem::take(&mut p.provided_by_module).into_iter());
         }
-        includes.extend(mem::take(&mut m.output.provides_by_module).into_iter());
+        includes.extend(mem::take(&mut m.output.provided_by_module).into_iter());
     }
 
     // preserve order of includes
@@ -313,7 +313,7 @@ fn test_{name}_layout() {{
         let rty = ctx.conv_map.find_or_alloc_rust_type(&f.ty, src_id);
         let field_fty = map_repr_c_type(ctx, &rty, rty.src_id_span())?;
 
-        for inc in &field_fty.provides_by_module {
+        for inc in &field_fty.provided_by_module {
             includes.insert(inc.clone());
         }
 
@@ -431,7 +431,7 @@ extern "C" {
         syn::ReturnType::Type(_, ref ty) => {
             let rty = ctx.conv_map.find_or_alloc_rust_type(ty, src_id);
             let fti = map_repr_c_type(ctx, &rty, (src_id, rty.ty.span()))?;
-            for inc in &fti.provides_by_module {
+            for inc in &fti.provided_by_module {
                 includes.insert(inc.clone());
             }
             fn_decl_out
@@ -456,7 +456,7 @@ extern "C" {
             FnArg::Default(named_arg) => {
                 let rty = ctx.conv_map.find_or_alloc_rust_type(&named_arg.ty, src_id);
                 let fti = map_repr_c_type(ctx, &rty, (src_id, rty.ty.span()))?;
-                for inc in &fti.provides_by_module {
+                for inc in &fti.provided_by_module {
                     includes.insert(inc.clone());
                 }
                 if i != 0 {

--- a/macroslib/src/cpp/fenum.rs
+++ b/macroslib/src/cpp/fenum.rs
@@ -48,7 +48,7 @@ pub(in crate::cpp) fn generate_enum(ctx: &mut CppContext, fenum: &ForeignEnumInf
 
     let enum_ftype = ForeignTypeS {
         name: ForeignTypeName::new(fenum.name.to_string(), (fenum.src_id, fenum.name.span())),
-        provides_by_module: vec![
+        provided_by_module: vec![
             format!("\"{}\"", cpp_code::cpp_header_name_for_enum(fenum)).into()
         ],
         into_from_rust: Some(ForeignConversionRule {

--- a/macroslib/src/cpp/finterface.rs
+++ b/macroslib/src/cpp/finterface.rs
@@ -100,7 +100,7 @@ pub(in crate::cpp) fn generate_interface(
             format!("std::unique_ptr<{}>", interface.name),
             interface.src_id_span(),
         ),
-        provides_by_module: vec![cpp_abs_class_header, "<memory>".into(), "<utility>".into()],
+        provided_by_module: vec![cpp_abs_class_header, "<memory>".into(), "<utility>".into()],
         into_from_rust: None,
         from_into_rust: Some(ForeignConversionRule {
             rust_ty: boxed_trait_rust_ty.to_idx(),
@@ -628,7 +628,7 @@ fn register_rust_type_and_c_type(
 
     ctx.conv_map.alloc_foreign_type(ForeignTypeS {
         name: ForeignTypeName::new(c_type_name, ext_span),
-        provides_by_module: vec![header_file],
+        provided_by_module: vec![header_file],
         into_from_rust: Some(ForeignConversionRule {
             rust_ty: rust_ty.to_idx(),
             intermediate: None,
@@ -691,7 +691,7 @@ fn register_reference(
 
     ctx.conv_map.alloc_foreign_type(ForeignTypeS {
         name: ForeignTypeName::new(cpp_type, (src_id, span)),
-        provides_by_module: vec![c_header_name],
+        provided_by_module: vec![c_header_name],
         into_from_rust: Some(ForeignConversionRule {
             rust_ty: ref_ty.to_idx(),
             intermediate: Some(ForeignConversionIntermediate {

--- a/macroslib/src/cpp/map_class_self_type.rs
+++ b/macroslib/src/cpp/map_class_self_type.rs
@@ -90,7 +90,7 @@ fn register_intermidiate_pointer_types(
             format!("{} *", cpp_code::c_class_type(class)),
             (class.src_id, class.name.span()),
         ),
-        provides_by_module: vec![format!("\"{}\"", cpp_code::c_header_name(class)).into()],
+        provided_by_module: vec![format!("\"{}\"", cpp_code::c_header_name(class)).into()],
         into_from_rust: Some(ForeignConversionRule {
             rust_ty: void_ptr_rust_ty,
             intermediate: None,
@@ -107,7 +107,7 @@ fn register_intermidiate_pointer_types(
             format!("const {} *", cpp_code::c_class_type(class)),
             (class.src_id, class.name.span()),
         ),
-        provides_by_module: vec![format!("\"{}\"", cpp_code::c_header_name(class)).into()],
+        provided_by_module: vec![format!("\"{}\"", cpp_code::c_header_name(class)).into()],
         into_from_rust: Some(ForeignConversionRule {
             rust_ty: const_void_ptr_rust_ty,
             intermediate: None,
@@ -256,7 +256,7 @@ fn register_main_foreign_types(
     );
     let class_ftype = ForeignTypeS {
         name: ForeignTypeName::new(class.name.to_string(), (class.src_id, class.name.span())),
-        provides_by_module: vec![format!("\"{}\"", cpp_code::cpp_header_name(class)).into()],
+        provided_by_module: vec![format!("\"{}\"", cpp_code::cpp_header_name(class)).into()],
         into_from_rust: Some(ForeignConversionRule {
             rust_ty: this_type,
             intermediate: Some(ForeignConversionIntermediate {
@@ -292,7 +292,7 @@ fn register_main_foreign_types(
             format!("const {} &", class.name),
             (class.src_id, class.name.span()),
         ),
-        provides_by_module: vec![format!("\"{}\"", cpp_code::cpp_header_name(class)).into()],
+        provided_by_module: vec![format!("\"{}\"", cpp_code::cpp_header_name(class)).into()],
         from_into_rust: Some(ForeignConversionRule {
             rust_ty: this_type_ref,
             intermediate: Some(ForeignConversionIntermediate {
@@ -320,7 +320,7 @@ fn register_main_foreign_types(
                 format!("{}Ref", class.name),
                 (class.src_id, class.name.span()),
             ),
-            provides_by_module: vec![format!("\"{}\"", cpp_code::cpp_header_name(class)).into()],
+            provided_by_module: vec![format!("\"{}\"", cpp_code::cpp_header_name(class)).into()],
             into_from_rust: Some(ForeignConversionRule {
                 rust_ty: this_type_ref,
                 intermediate: Some(ForeignConversionIntermediate {
@@ -347,7 +347,7 @@ fn register_main_foreign_types(
             format!("{} &", class.name),
             (class.src_id, class.name.span()),
         ),
-        provides_by_module: vec![format!("\"{}\"", cpp_code::cpp_header_name(class)).into()],
+        provided_by_module: vec![format!("\"{}\"", cpp_code::cpp_header_name(class)).into()],
         from_into_rust: Some(ForeignConversionRule {
             rust_ty: this_type_mut_ref,
             intermediate: Some(ForeignConversionIntermediate {
@@ -381,7 +381,7 @@ fn register_main_foreign_types(
                     "/**/",
                     (class.src_id, class.name.span()),
                 ),
-                provides_by_module: vec![format!("\"{}\"", cpp_code::cpp_header_name(class)).into()],
+                provided_by_module: vec![format!("\"{}\"", cpp_code::cpp_header_name(class)).into()],
                 from_into_rust: Some(ForeignConversionRule {
                     rust_ty: self_type_mut_ref.to_idx(),
                     intermediate: Some(ForeignConversionIntermediate {
@@ -413,7 +413,7 @@ fn register_main_foreign_types(
                     "/**/",
                     (class.src_id, class.name.span()),
                 ),
-                provides_by_module: vec![format!("\"{}\"", cpp_code::cpp_header_name(class)).into()],
+                provided_by_module: vec![format!("\"{}\"", cpp_code::cpp_header_name(class)).into()],
                 from_into_rust: Some(ForeignConversionRule {
                     rust_ty: self_type_ref.to_idx(),
                     intermediate: Some(ForeignConversionIntermediate {

--- a/macroslib/src/cpp/map_type.rs
+++ b/macroslib/src/cpp/map_type.rs
@@ -234,7 +234,7 @@ impl<'a, 'b> TypeMapConvRuleInfoExpanderHelper for CppContextForArg<'a, 'b> {
                 fname.value().replace("struct ", "").replace("union ", ""),
                 fname.unique_prefix().unwrap_or(""),
             ),
-            provides_by_module: f_info.provides_by_module.clone(),
+            provided_by_module: f_info.provided_by_module.clone(),
         })
     }
     fn swig_foreign_to_i_type(&mut self, ty: &syn::Type, var_name: &str) -> Result<String> {

--- a/macroslib/src/cpp/mod.rs
+++ b/macroslib/src/cpp/mod.rs
@@ -77,7 +77,7 @@ struct CppConverter {
 #[derive(Debug)]
 struct CppForeignTypeInfo {
     base: ForeignTypeInfo,
-    provides_by_module: Vec<SmolStr>,
+    provided_by_module: Vec<SmolStr>,
     input_to_output: bool,
     pub(in crate::cpp) cpp_converter: Option<CppConverter>,
 }
@@ -115,7 +115,7 @@ impl CppForeignTypeInfo {
                 ),
             )
         })?;
-        let mut provides_by_module = ftype.provides_by_module.clone();
+        let mut provided_by_module = ftype.provided_by_module.clone();
         let base_rt;
         let base_ft_name;
         let mut input_to_output = false;
@@ -160,7 +160,7 @@ impl CppForeignTypeInfo {
                     },
                 ));
             }
-            provides_by_module.extend_from_slice(&inter_ft.provides_by_module);
+            provided_by_module.extend_from_slice(&inter_ft.provided_by_module);
             base_ft_name = inter_ft.base.name;
             cpp_converter = Some(CppConverter {
                 typename,
@@ -181,7 +181,7 @@ impl CppForeignTypeInfo {
                 name: base_ft_name,
                 correspoding_rust_type: ctx.conv_map[base_rt].clone(),
             },
-            provides_by_module,
+            provided_by_module,
             cpp_converter,
         })
     }
@@ -206,7 +206,7 @@ impl From<ForeignTypeInfo> for CppForeignTypeInfo {
                 name: x.name,
                 correspoding_rust_type: x.correspoding_rust_type,
             },
-            provides_by_module: Vec::new(),
+            provided_by_module: Vec::new(),
             cpp_converter: None,
         }
     }
@@ -464,7 +464,7 @@ fn register_c_type(
             };
             tmap.alloc_foreign_type(ForeignTypeS {
                 name: ForeignTypeName::new(c_name, (src_id, f_ident.span())),
-                provides_by_module: vec![format!("\"{}\"", c_types.header_name).into()],
+                provided_by_module: vec![format!("\"{}\"", c_types.header_name).into()],
                 into_from_rust: Some(rule.clone()),
                 from_into_rust: Some(rule),
             })?;

--- a/macroslib/src/java_jni/fenum.rs
+++ b/macroslib/src/java_jni/fenum.rs
@@ -51,7 +51,7 @@ pub(in crate::java_jni) fn generate_enum(
 
     let enum_ftype = ForeignTypeS {
         name: ForeignTypeName::new(fenum.name.to_string(), (fenum.src_id, fenum.name.span())),
-        provides_by_module: vec![],
+        provided_by_module: vec![],
         into_from_rust: Some(ForeignConversionRule {
             rust_ty: enum_rty.to_idx(),
             intermediate: Some(ForeignConversionIntermediate {

--- a/macroslib/src/java_jni/map_class_self_type.rs
+++ b/macroslib/src/java_jni/map_class_self_type.rs
@@ -184,7 +184,7 @@ fn register_main_foreign_types(
                 &name_prefix,
                 (class.src_id, class.name.span()),
             ),
-            provides_by_module: vec![],
+            provided_by_module: vec![],
             from_into_rust: None,
             into_from_rust: Some(ForeignConversionRule {
                 rust_ty: jlong_out_val_rty.to_idx(),
@@ -278,7 +278,7 @@ fn register_main_foreign_types(
                 &name_prefix,
                 (class.src_id, class.name.span()),
             ),
-            provides_by_module: vec![],
+            provided_by_module: vec![],
             into_from_rust: None,
             from_into_rust: Some(ForeignConversionRule {
                 rust_ty: jlong_in_val_rty.to_idx(),
@@ -313,7 +313,7 @@ fn register_main_foreign_types(
 
     let class_ftype = ForeignTypeS {
         name: ForeignTypeName::new(format!("{}{}", null_annot, class.name), (class.src_id, class.name.span())),
-        provides_by_module: vec![],
+        provided_by_module: vec![],
         into_from_rust: Some(ForeignConversionRule {
             rust_ty: this_type,
             intermediate: Some(ForeignConversionIntermediate {
@@ -356,7 +356,7 @@ fn register_main_foreign_types(
             "/*ref*/",
             (class.src_id, class.name.span()),
         ),
-        provides_by_module: vec![],
+        provided_by_module: vec![],
         from_into_rust: Some(ForeignConversionRule {
             rust_ty: this_type_ref,
             intermediate: Some(ForeignConversionIntermediate {
@@ -387,7 +387,7 @@ fn register_main_foreign_types(
             "/*mut ref*/",
             (class.src_id, class.name.span()),
         ),
-        provides_by_module: vec![],
+        provided_by_module: vec![],
         from_into_rust: Some(ForeignConversionRule {
             rust_ty: this_type_mut_ref,
             intermediate: Some(ForeignConversionIntermediate {
@@ -430,7 +430,7 @@ fn register_main_foreign_types(
                     "/*ref 2*/",
                     (class.src_id, class.name.span()),
                 ),
-                provides_by_module: vec![],
+                provided_by_module: vec![],
                 from_into_rust: Some(ForeignConversionRule {
                     rust_ty: self_type_mut_ref.to_idx(),
                     intermediate: Some(ForeignConversionIntermediate {
@@ -461,7 +461,7 @@ fn register_main_foreign_types(
                     "/*mut ref 2*/",
                     (class.src_id, class.name.span()),
                 ),
-                provides_by_module: vec![],
+                provided_by_module: vec![],
                 from_into_rust: Some(ForeignConversionRule {
                     rust_ty: self_type_ref.to_idx(),
                     intermediate: Some(ForeignConversionIntermediate {

--- a/macroslib/src/java_jni/map_type.rs
+++ b/macroslib/src/java_jni/map_type.rs
@@ -34,7 +34,7 @@ pub(in crate::java_jni) fn map_type(
     let fti = do_map_type(ctx, arg_ty, direction, arg_ty_span)?;
     let ftype = &ctx.conv_map[fti];
     let origin_ftype_span = ftype.src_id_span();
-    if !ftype.provides_by_module.is_empty() {
+    if !ftype.provided_by_module.is_empty() {
         unimplemented!();
     }
     let rule = match direction {
@@ -300,7 +300,7 @@ impl<'a, 'b> TypeMapConvRuleInfoExpanderHelper for JavaContextForArg<'a, 'b> {
         };
         Ok(ExpandedFType {
             name: fname,
-            provides_by_module: vec![],
+            provided_by_module: vec![],
         })
     }
     fn swig_foreign_to_i_type(&mut self, _ty: &syn::Type, _var_name: &str) -> Result<String> {

--- a/macroslib/src/lib.rs
+++ b/macroslib/src/lib.rs
@@ -734,7 +734,7 @@ impl Generator {
 
         if self.conv_map.is_empty() {
             return Err(DiagnosticError::new_without_src_info(
-                "After merge all \"types maps\" have no convertion code",
+                "After merge all \"types maps\" have no conversion code",
             ));
         }
 

--- a/macroslib/src/python/mod.rs
+++ b/macroslib/src/python/mod.rs
@@ -185,7 +185,7 @@ impl PythonConfig {
                 enum_info.name.to_string(),
                 (enum_info.src_id, enum_info.name.span()),
             ),
-            provides_by_module: vec![],
+            provided_by_module: vec![],
             into_from_rust: None,
             from_into_rust: None,
         };

--- a/macroslib/src/python/mod.rs
+++ b/macroslib/src/python/mod.rs
@@ -298,7 +298,7 @@ fn generate_method_code(
     } else {
         0
     };
-    let (args_list, mut args_convertions): (Vec<_>, Vec<_>) = method
+    let (args_list, mut args_conversions): (Vec<_>, Vec<_>) = method
         .fn_decl
         .inputs
         .iter()
@@ -307,7 +307,7 @@ fn generate_method_code(
             let named_arg = a
                 .as_named_arg()
                 .map_err(|err| DiagnosticError::from_syn_err(class.src_id, err))?;
-            let (arg_type, arg_convertion) = generate_conversion_for_argument(
+            let (arg_type, arg_conversion) = generate_conversion_for_argument(
                 &conv_map.find_or_alloc_rust_type(&named_arg.ty, class.src_id),
                 method.span(),
                 class.src_id,
@@ -315,13 +315,13 @@ fn generate_method_code(
                 &named_arg.name,
                 true,
             )?;
-            Ok(((&named_arg.name, arg_type), arg_convertion))
+            Ok(((&named_arg.name, arg_type), arg_conversion))
         })
         .collect::<Result<Vec<_>>>()?
         .into_iter()
         .unzip();
-    if let Some(self_convertion) = self_type_conversion(class, method, conv_map)? {
-        args_convertions.insert(0, self_convertion);
+    if let Some(self_conversion) = self_type_conversion(class, method, conv_map)? {
+        args_conversions.insert(0, self_conversion);
     }
     let mut args_list_tokens = args_list
         .into_iter()
@@ -349,7 +349,7 @@ fn generate_method_code(
         class.src_id,
         conv_map,
         quote! {
-            #method_rust_path(#( #args_convertions ),*)
+            #method_rust_path(#( #args_conversions ),*)
         },
     )?;
     let docstring = if !method_name.to_string().starts_with("__") {

--- a/macroslib/src/typemap/merge.rs
+++ b/macroslib/src/typemap/merge.rs
@@ -100,8 +100,8 @@ impl TypeMap {
                 r_ty,
             )?;
             let ftype = &mut self.ftypes_storage[ftype_idx];
-            ftype.provides_by_module =
-                convert_req_module_to_provides_by_module(req_modules.to_vec());
+            ftype.provided_by_module =
+                convert_req_module_to_provided_by_module(req_modules.to_vec());
             set_unique_prefix(ftype, unique_prefix.cloned(), src_id)?;
             return Ok(());
         }
@@ -316,8 +316,8 @@ impl TypeMap {
                     &self.conv_graph,
                 )?;
                 res_ftype.from_into_rust = Some(from_into_rust);
-                res_ftype.provides_by_module =
-                    convert_req_module_to_provides_by_module(req_modules);
+                res_ftype.provided_by_module =
+                    convert_req_module_to_provided_by_module(req_modules);
                 set_unique_prefix(res_ftype, ft_unique_prefix, src_id)?;
             }
             (Some((ft, into_from_rust)), None) => {
@@ -330,8 +330,8 @@ impl TypeMap {
                     &self.conv_graph,
                 )?;
                 res_ftype.into_from_rust = Some(into_from_rust);
-                res_ftype.provides_by_module =
-                    convert_req_module_to_provides_by_module(req_modules);
+                res_ftype.provided_by_module =
+                    convert_req_module_to_provided_by_module(req_modules);
                 set_unique_prefix(res_ftype, ft_unique_prefix, src_id)?;
             }
             (None, Some((ft, from_into_rust))) => {
@@ -344,8 +344,8 @@ impl TypeMap {
                     &self.conv_graph,
                 )?;
                 res_ftype.from_into_rust = Some(from_into_rust);
-                res_ftype.provides_by_module =
-                    convert_req_module_to_provides_by_module(req_modules);
+                res_ftype.provided_by_module =
+                    convert_req_module_to_provided_by_module(req_modules);
                 set_unique_prefix(res_ftype, ft_unique_prefix, src_id)?;
             }
             (None, None) => {}
@@ -465,7 +465,7 @@ fn ftype_merge(our: &mut ForeignTypeS, extrn_ft: ForeignTypeS) {
     }
 }
 
-fn convert_req_module_to_provides_by_module(v: Vec<ModuleName>) -> Vec<SmolStr> {
+fn convert_req_module_to_provided_by_module(v: Vec<ModuleName>) -> Vec<SmolStr> {
     let mut ret = Vec::with_capacity(v.len());
     for x in v {
         ret.push(x.name);

--- a/macroslib/src/typemap/ty.rs
+++ b/macroslib/src/typemap/ty.rs
@@ -158,7 +158,7 @@ pub(crate) struct ForeignTypeS {
     /// specify which foreign module provides this type
     /// it is possible that provided by multiplines modules
     /// for example C++ `std::variant<TypeA, TypeB>
-    pub provides_by_module: Vec<SmolStr>,
+    pub provided_by_module: Vec<SmolStr>,
     pub into_from_rust: Option<ForeignConversionRule>,
     pub from_into_rust: Option<ForeignConversionRule>,
 }
@@ -206,7 +206,7 @@ impl ForeignTypesStorage {
         };
         self.add_new_ftype(ForeignTypeS {
             name: tn,
-            provides_by_module: Vec::new(),
+            provided_by_module: Vec::new(),
             into_from_rust: Some(rule.clone()),
             from_into_rust: Some(rule),
         })
@@ -237,7 +237,7 @@ impl ForeignTypesStorage {
         } else {
             let ftype = ForeignTypeS {
                 name: ftype_name,
-                provides_by_module: Vec::new(),
+                provided_by_module: Vec::new(),
                 into_from_rust: None,
                 from_into_rust: None,
             };

--- a/macroslib/src/typemap/typemap_macro/tests.rs
+++ b/macroslib/src/typemap/typemap_macro/tests.rs
@@ -680,7 +680,7 @@ impl TypeMapConvRuleInfoExpanderHelper for Dummy {
                 panic!("swig_f_type: Unknown type: {}", DisplayToTokens(ty));
             }
             .into(),
-            provides_by_module: vec![],
+            provided_by_module: vec![],
         })
     }
     fn swig_foreign_to_i_type(&mut self, _ty: &syn::Type, var_name: &str) -> Result<String> {


### PR DESCRIPTION
For those, I prefered to have a separate commit per change type.
- `provided_by_module` instead of `provides_by_module`,
- `arg_conversion` instead of `arg_convertion`,
- Another `conversion` fix.

**Attention**
As the field `provided_by_module` is used in many places, this may break pending developements / fixes.

I may squash all, if you prefer.
Tell me.
