### PR TITLE
Fixed harlmess duplicate generated code with Vec<T> and possibly other cases.

### DIFF
--- a/macroslib/tests/expectations/cpp_code_cache.cpp
+++ b/macroslib/tests/expectations/cpp_code_cache.cpp
@@ -1,0 +1,21 @@
+r#"
+#ifdef __cplusplus
+extern "C" {
+#endif
+void CRustVecu8_free(struct CRustVecu8 v);
+#ifdef __cplusplus
+} // extern "C" {
+#endif
+
+#ifdef __cplusplus
+
+#include "rust_vec_impl.hpp"
+
+namespace org_examples {
+using RustVecu8 = RustVec<CRustVecu8, CRustVecu8_free>;
+}
+
+#endif
+
+>>> end of file: "rust_vec_u8.h" <<<
+"#;

--- a/macroslib/tests/expectations/cpp_code_cache.rs
+++ b/macroslib/tests/expectations/cpp_code_cache.rs
@@ -1,0 +1,10 @@
+// Before #435, a part of generated code is duplicated.
+// This test case makes sure that this does not happen anymore.
+
+foreign_class!(
+    class Foo {
+        fn Foo::return_is_array_u8() -> Vec<u8>;
+        fn Foo::param_is_array_u8(_: Vec<u8>);
+    }
+);
+

--- a/macroslib/tests/expectations/tests.list
+++ b/macroslib/tests/expectations/tests.list
@@ -2,6 +2,7 @@ bool_in_out_interface
 bool_in_out
 circular_deps
 class_with_dummy_constructor
+cpp_code_cache
 cpp_include_custom_rule
 cpp_include_return_only_result_vec
 cpp_qdate_typemap

--- a/macroslib/tests/test_expectations.rs
+++ b/macroslib/tests/test_expectations.rs
@@ -574,8 +574,10 @@ fn collect_code_in_dir(dir_with_code: &Path, exts: &[&str]) -> Result<String, Er
                 .iter()
                 .any(|ext| path.path().to_str().map_or(false, |x| x.ends_with(ext)))
         {
+            code.push_str(format!("<<< generated file: {:?} >>>\n", path.file_name()).as_str());
             code.push_str(&fs::read_to_string(path.path())?);
             code.push('\n');
+            code.push_str(format!(">>> end of file: {:?} <<<\n", path.file_name()).as_str());
         }
     }
     Ok(code)


### PR DESCRIPTION
As discussed on #435, the code generation may create duplicate generated code.
Most of the time, it's harmless, but it may bring troubles later or with
other parts of code.

This happens in the following scenario when there is a function
having a Vec<T> in parameter and another one as return value:

```
    class Foo {
        fn Foo::return_is_array_u8() -> Vec<u8>;
        fn Foo::param_is_array_u8(_: Vec<u8>);
    }
```
If there is :
- only one of them,
- or a unique function having both,
the duplicate generated code is not seen.

In this fix, a `foreign_code_cache` is added to `CppContext`.
This cache is checked before writing from `cpp-include.rs` code rules.
When the code entry is already present in the cache, it's no more written
to FileWriteCache.