### PR TITLE
Make build script runs reproducible

### DIFF
--- a/macroslib/Cargo.toml
+++ b/macroslib/Cargo.toml
@@ -32,5 +32,6 @@ tempfile = "3.0"
 jni-sys = "0.3.0"
 
 [build-dependencies]
+rustc-hash = "1.0.1"
 syn = { version = "1.0", features = ["full", "extra-traits", "visit-mut", "visit"] }
 quote = "1.0"

--- a/macroslib/src/java_jni/find_cache.rs
+++ b/macroslib/src/java_jni/find_cache.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use syn::{
     parse::{Parse, ParseStream},
     parse_quote,
@@ -9,7 +9,7 @@ use syn::{
 
 #[derive(Default)]
 pub struct JniCacheMacroCalls {
-    pub calls: HashMap<String, JniFindClass>,
+    pub calls: FxHashMap<String, JniFindClass>,
 }
 
 impl JniCacheMacroCalls {


### PR DESCRIPTION
Build script runs are currently not reproducible due to non-determinism of generated Rust code.

Only issue I ran into was during creation of JNI constants and JNI load/unload hooks. This PR adopts a sorted map, thus iteration order becomes deterministic across builds.