### PR TITLE
Replaced #[no_mangle] with #[unsafe(no_mangle)] as required by rust 2024

### DIFF
--- a/macroslib/src/cpp/cpp-include.rs
+++ b/macroslib/src/cpp/cpp-include.rs
@@ -414,13 +414,13 @@ foreign_typemap!(
             capacity: usize,
         }
 
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub extern "C" fn crust_string_free(x: CRustString) {
             let s = unsafe { String::from_raw_parts(x.data as *mut u8, x.len, x.capacity) };
             drop(s);
         }
 
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub extern "C" fn crust_string_clone(x: CRustString) -> CRustString {
             let s = unsafe { String::from_raw_parts(x.data as *mut u8, x.len, x.capacity) };
             let ret = CRustString::from_string(s.clone());
@@ -908,7 +908,7 @@ foreign_typemap!(
             capacity: usize,
         }
 
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub extern "C" fn CRustVecFree!()(v: CRustVec!()) {
             let v = unsafe { Vec::from_raw_parts(v.data as *mut swig_subst_type!(T), v.len, v.capacity) };
             drop(v);
@@ -1035,23 +1035,23 @@ foreign_typemap!(
     define_c_type!(
         module = "CForeignVecModule!().h";
         #[allow(unused_variables, unused_mut, non_snake_case, unused_unsafe)]
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub extern "C" fn CForeignVecFree!()(v: CRustForeignVec) {
             drop_foreign_class_vec::<swig_subst_type!(T)>(v);
         }
 
         #[allow(unused_variables, unused_mut, non_snake_case, unused_unsafe)]
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub extern "C" fn CForeignVecPush!()(v: *mut CRustForeignVec, e: *mut ::std::os::raw::c_void) {
             push_foreign_class_to_vec::<swig_subst_type!(T)>(v, e);
         }
 
         #[allow(unused_variables, unused_mut, non_snake_case, unused_unsafe)]
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub extern "C" fn CForeignVecRemove!()(v: *mut CRustForeignVec, idx: usize) -> *mut ::std::os::raw::c_void {
             remove_foreign_class_from_vec::<swig_subst_type!(T)>(v, idx)
         }
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub static CForeignVecElemSize!() : usize = ::std::mem::size_of::<swig_subst_type!(T)>();
     );
 

--- a/macroslib/src/cpp/fclass.rs
+++ b/macroslib/src/cpp/fclass.rs
@@ -613,7 +613,7 @@ May be you need to use `private constructor = empty;` syntax?",
         let code = format!(
             r#"
 #[allow(unused_variables, unused_mut, non_snake_case, unused_unsafe)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn {c_destructor_name}(this: *mut {this_type}) {{
 {unpack_code}
     drop(this);
@@ -816,7 +816,7 @@ fn generate_static_method(conv_map: &mut TypeMap, mc: &MethodContext) -> Result<
     let code = format!(
         r#"
 #[allow(non_snake_case, unused_variables, unused_mut, unused_unsafe)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn {func_name}({decl_func_args}) -> {c_ret_type} {{
 {convert_input_code}
     let mut {ret_name}: {real_output_typename} = {call};
@@ -892,7 +892,7 @@ fn generate_method(
     let code = format!(
         r#"
 #[allow(non_snake_case, unused_variables, unused_mut, unused_unsafe)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn {func_name}(this: *mut {this_type}, {decl_func_args}) -> {c_ret_type} {{
 {convert_input_code}
     let this: {this_type_ref} = unsafe {{
@@ -957,7 +957,7 @@ fn generate_constructor(
     let code = format!(
         r#"
 #[allow(unused_variables, unused_mut, non_snake_case, unused_unsafe)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn {func_name}({decl_func_args}) -> *const ::std::os::raw::c_void {{
 {convert_input_code}
     let this: {real_output_typename} = {call};
@@ -1356,7 +1356,7 @@ fn generate_copy_stuff(
 
         ctx.rust_code.push(quote! {
             #[allow(non_snake_case, unused_variables, unused_mut, unused_unsafe)]
-            #[no_mangle]
+            #[unsafe(no_mangle)]
             pub extern "C" fn #clone_fn_name(this: *const #this_type_for_method_ty) -> *mut ::std::os::raw::c_void {
                 #unpack_code
                 let ret: #this_type_ty = this.clone();

--- a/macroslib/src/java_jni/fclass.rs
+++ b/macroslib/src/java_jni/fclass.rs
@@ -729,7 +729,7 @@ May be you need to use `private constructor = empty;` syntax?",
         let code = format!(
             r#"
 #[allow(unused_variables, unused_mut, non_snake_case, unused_unsafe)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn {jni_destructor_name}(env: *mut JNIEnv, _: jclass, this: jlong) {{
     let this: *mut {this_type} = unsafe {{
         jlong_to_pointer::<{this_type}>(this).as_mut().unwrap()
@@ -856,7 +856,7 @@ fn generate_static_method(ctx: &mut JavaContext, mc: &MethodContext) -> Result<(
     let code = format!(
         r#"
 #[allow(non_snake_case, unused_variables, unused_mut, unused_unsafe)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn {func_name}(env: *mut JNIEnv, _: jclass, {decl_func_args}) -> {jni_ret_type} {{
 {convert_input_code}
     let mut {ret_name}: {real_output_typename} = {call};
@@ -921,7 +921,7 @@ fn generate_constructor(
     let code = format!(
         r#"
 #[allow(unused_variables, unused_mut, non_snake_case, unused_unsafe)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn {func_name}(env: *mut JNIEnv, _: jclass, {decl_func_args}) -> jlong {{
 {convert_input_code}
     let this: {real_output_typename} = {call};
@@ -1005,7 +1005,7 @@ fn generate_method(
     let code = format!(
         r#"
 #[allow(non_snake_case, unused_variables, unused_mut, unused_unsafe)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C"
  fn {func_name}(env: *mut JNIEnv, _: jclass, this: jlong, {decl_func_args}) -> {jni_ret_type} {{
 {convert_input_code}

--- a/macroslib/src/java_jni/mod.rs
+++ b/macroslib/src/java_jni/mod.rs
@@ -446,7 +446,7 @@ package {package};
                 let jni_args = &jni_args;
                 ctx.rust_code.push(quote! {
                     #[allow(unused_variables, unused_mut, non_snake_case, unused_unsafe)]
-                    #[no_mangle]
+                    #[unsafe(no_mangle)]
                     pub extern "C" fn #jni_func_name(_env: *mut JNIEnv, _: jclass, #(#jni_args),*) {
                     }
                 });

--- a/macroslib/src/java_jni/rust_code.rs
+++ b/macroslib/src/java_jni/rust_code.rs
@@ -275,7 +275,7 @@ pub(in crate::java_jni) fn generate_load_unload_jni_funcs(
     }
 
     let jni_load_func: syn::Item = parse_quote! {
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub extern "system" fn JNI_OnLoad(java_vm: *mut JavaVM, _reserved: *mut ::std::os::raw::c_void) -> jint {
             log::debug!("JNI_OnLoad begin");
             assert!(!java_vm.is_null());
@@ -298,7 +298,7 @@ pub(in crate::java_jni) fn generate_load_unload_jni_funcs(
     };
     addon_code.push(jni_load_func);
     let jni_unload_func: syn::Item = parse_quote! {
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub extern "system" fn JNI_OnUnload(java_vm: *mut JavaVM, _reserved: *mut ::std::os::raw::c_void) {
             log::debug!("JNI_OnUnLoad begin");
             assert!(!java_vm.is_null());

--- a/macroslib/src/typemap/typemap_macro/parse.rs
+++ b/macroslib/src/typemap/typemap_macro/parse.rs
@@ -356,11 +356,11 @@ impl syn::parse::Parse for CItemsList {
                     types.push(CItem::Union(u));
                 }
                 syn::Item::Fn(f) => {
-                    let mangle_attr: syn::Attribute = parse_quote! { #[no_mangle] };
+                    let mangle_attr: syn::Attribute = parse_quote! { #[unsafe(no_mangle)] };
                     if !f.attrs.iter().any(|a| *a == mangle_attr) {
                         return Err(syn::Error::new(
                             f.span(),
-                            "fn has no #[no_mangle] attribute",
+                            "fn has no #[unsafe(no_mangle)] attribute",
                         ));
                     }
 
@@ -382,11 +382,11 @@ impl syn::parse::Parse for CItemsList {
                     types.push(CItem::Fn(f));
                 }
                 syn::Item::Static(s) => {
-                    let mangle_attr: syn::Attribute = parse_quote! { #[no_mangle] };
+                    let mangle_attr: syn::Attribute = parse_quote! { #[unsafe(no_mangle)] };
                     if !s.attrs.iter().any(|a| *a == mangle_attr) {
                         return Err(syn::Error::new(
                             s.span(),
-                            "static has no #[no_mangle] attribute",
+                            "static has no #[unsafe(no_mangle)] attribute",
                         ));
                     }
 

--- a/macroslib/tests/expectations/bool_in_out.cpp_rs
+++ b/macroslib/tests/expectations/bool_in_out.cpp_rs
@@ -11,7 +11,7 @@ r#"pub extern "C" fn Foo_new ( a0 : :: std :: os :: raw :: c_char , ) -> * const
  let this : * mut Foo = Box :: into_raw ( this ) ;
  this as * const :: std :: os :: raw :: c_void
  }"#;
-r#"# [ no_mangle ]
+r#"# [ unsafe ( no_mangle ) ]
  pub extern "C" fn Foo_f2 ( a0 : :: std :: os :: raw :: c_char , ) -> :: std :: os :: raw :: c_char {
  let mut a0 : bool = a0 != 0 ;
  let mut ret : bool = f2 ( a0 ) ;

--- a/macroslib/tests/expectations/bool_in_out.java_rs
+++ b/macroslib/tests/expectations/bool_in_out.java_rs
@@ -1,4 +1,4 @@
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_example_Foo_do_1f1(
     env: *mut JNIEnv,
     _: jclass,
@@ -12,7 +12,7 @@ pub extern "C" fn Java_org_example_Foo_do_1f1(
     ret
 }"##;
 
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_example_Foo_f2(env: *mut JNIEnv, _: jclass, a0: jboolean) -> jboolean {
     let mut a0: bool = a0 != 0;
     let mut ret: bool = f2(a0);
@@ -21,7 +21,7 @@ pub extern "C" fn Java_org_example_Foo_f2(env: *mut JNIEnv, _: jclass, a0: jbool
 }"##;
 
 
-r##"# [ no_mangle ] pub extern "C" fn Java_org_example_Foo_init ( env : * mut JNIEnv , _ : jclass , a0 : jboolean , ) -> jlong {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn Java_org_example_Foo_init ( env : * mut JNIEnv , _ : jclass , a0 : jboolean , ) -> jlong {
  let mut a0 : bool = a0 != 0;
  let this : Foo = Foo :: new ( a0 ) ;
  let this : Box < Foo > = Box :: new ( this ) ;

--- a/macroslib/tests/expectations/callback_with_several_traits.cpp_rs
+++ b/macroslib/tests/expectations/callback_with_several_traits.cpp_rs
@@ -1,4 +1,4 @@
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Test_f(a0: *const C_MyObserver) -> () {
     assert!(!a0.is_null());
     let a0: &C_MyObserver = unsafe { a0.as_ref().unwrap() };

--- a/macroslib/tests/expectations/circular_deps.java_rs
+++ b/macroslib/tests/expectations/circular_deps.java_rs
@@ -1,9 +1,9 @@
-r#"# [ no_mangle ] pub extern "C" fn Java_org_example_A_do_1a ( env : * mut JNIEnv , _ : jclass , b : jlong , ) -> ( ) {
+r#"# [ unsafe ( no_mangle ) ] pub extern "C" fn Java_org_example_A_do_1a ( env : * mut JNIEnv , _ : jclass , b : jlong , ) -> ( ) {
  let b : & B = unsafe { jlong_to_pointer ::< B > ( b ) . as_mut ( ) . unwrap ( ) } ;
  let mut ret : ( ) = A :: a ( b ) ;
  ret
  }"#;
-r#"# [ no_mangle ] pub extern "C" fn Java_org_example_B_do_1b ( env : * mut JNIEnv , _ : jclass , a : jlong , ) -> ( ) {
+r#"# [ unsafe ( no_mangle ) ] pub extern "C" fn Java_org_example_B_do_1b ( env : * mut JNIEnv , _ : jclass , a : jlong , ) -> ( ) {
  let a : & A = unsafe { jlong_to_pointer ::< A > ( a ) . as_mut ( ) . unwrap ( ) } ;
  let mut ret : ( ) = B :: b ( a ) ;
  ret

--- a/macroslib/tests/expectations/cpp_generic_ptr_rule.cpp_rs
+++ b/macroslib/tests/expectations/cpp_generic_ptr_rule.cpp_rs
@@ -1,4 +1,4 @@
-r##"# [ no_mangle ] pub extern "C" fn Foo_f ( a : * const MapRect , ) -> ( ) {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn Foo_f ( a : * const MapRect , ) -> ( ) {
  assert ! ( ! a . is_null ( ) ) ;
  let map_rect : & MapRect = unsafe { &* a } ;
  let points_arr : [ MapPoint ; 4 ] = map_rect . into ( ) ;

--- a/macroslib/tests/expectations/cpp_return_option.cpp_rs
+++ b/macroslib/tests/expectations/cpp_return_option.cpp_rs
@@ -1,4 +1,4 @@
-r##"# [ no_mangle ] pub extern "C" fn Foo_f6 ( this : * mut Foo , ) -> CRustOptionu32 {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn Foo_f6 ( this : * mut Foo , ) -> CRustOptionu32 {
  let this : & Foo = unsafe { this . as_mut ( ) . unwrap ( ) } ;
  let mut ret : Option < ControlItem > = Foo :: f6 ( this , ) ;
  let mut ret : CRustOptionu32 = match ret { Some ( mut x ) => {

--- a/macroslib/tests/expectations/cpp_return_tuple.cpp_rs
+++ b/macroslib/tests/expectations/cpp_return_tuple.cpp_rs
@@ -1,4 +1,4 @@
-r##"# [ no_mangle ] pub extern "C" fn Foo_f ( this : * mut Foo , ) -> CRustPair4232mut3232c_void4232mut3232c_void {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn Foo_f ( this : * mut Foo , ) -> CRustPair4232mut3232c_void4232mut3232c_void {
  let this : & Foo = unsafe { this . as_mut ( ) . unwrap ( ) } ;
  let mut ret : ( One , Two ) = Foo :: f ( this , ) ;
  let p0 : * mut :: std :: os :: raw :: c_void = < One >:: box_object ( ret . 0 ) ;
@@ -7,7 +7,7 @@ r##"# [ no_mangle ] pub extern "C" fn Foo_f ( this : * mut Foo , ) -> CRustPair4
  ret }"##;
 
 r##"
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn Foo_g(this: *mut Foo) -> CRustPairi32i32 {
     let this: &Foo = unsafe { this.as_mut().unwrap() };
     let mut ret: (i32, i32) = Foo::g(this);
@@ -31,7 +31,7 @@ pub struct CRustPairi32i32 {
 "##;
 
 r##"
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn Foo_h(this: *mut Foo) -> CRustPairCRustStrViewCRustStrView {
     let this: &Foo = unsafe { this.as_mut().unwrap() };
     let mut ret: (&str, &str) = Foo::h(this);

--- a/macroslib/tests/expectations/foreign_class_as_arg_type_simple.cpp_rs
+++ b/macroslib/tests/expectations/foreign_class_as_arg_type_simple.cpp_rs
@@ -9,7 +9,7 @@ r#"fn Boo_with_foo ( f : * mut :: std :: os :: raw :: c_void , ) -> * const :: s
  this as * const :: std :: os :: raw :: c_void
  }"#;
 
-r##"# [ no_mangle ] pub extern "C" fn Boo_f ( this : * mut Boo , foo : * mut :: std :: os :: raw :: c_void , ) -> usize {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn Boo_f ( this : * mut Boo , foo : * mut :: std :: os :: raw :: c_void , ) -> usize {
  assert ! ( ! foo . is_null ( ) ) ;
  let foo : * mut Foo = foo as * mut Foo ;
  let foo : Box < Foo > = unsafe { Box :: from_raw ( foo ) } ;
@@ -19,7 +19,7 @@ r##"# [ no_mangle ] pub extern "C" fn Boo_f ( this : * mut Boo , foo : * mut :: 
  ret
  }"##;
 
-r##"# [ no_mangle ] pub extern "C" fn Boo_f2 ( a0 : f64 , foo : * mut :: std :: os :: raw :: c_void , ) -> i32 {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn Boo_f2 ( a0 : f64 , foo : * mut :: std :: os :: raw :: c_void , ) -> i32 {
  assert ! ( ! foo . is_null ( ) ) ;
  let foo : * mut Foo = foo as * mut Foo ;
  let foo : Box < Foo > = unsafe { Box :: from_raw ( foo ) } ;

--- a/macroslib/tests/expectations/foreign_vec_as_arg_cpp.cpp_rs
+++ b/macroslib/tests/expectations/foreign_vec_as_arg_cpp.cpp_rs
@@ -1,11 +1,11 @@
-r##"# [ no_mangle ] pub extern "C" fn FooImpl_alternateBoarding ( this : * mut Foo , ) -> CRustObjectSlice {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn FooImpl_alternateBoarding ( this : * mut Foo , ) -> CRustObjectSlice {
  let this : & Foo = unsafe { this . as_mut ( ) . unwrap ( ) } ;
  let mut ret : & [ Boo ] = Foo :: alternate_boarding ( this , ) ;
  let mut ret : CRustObjectSlice = CRustObjectSlice { data : ret . as_ptr ( ) as * const :: std :: os :: raw :: c_void , len : ret . len ( ) , step : :: std :: mem :: size_of ::< Boo > ( ) , } ;
  ret }"##;
 
 
-r##"# [ no_mangle ] pub extern "C" fn FooImpl_setAlternateBoarding ( this : * mut Foo , p : CRustForeignVec , ) -> ( ) {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn FooImpl_setAlternateBoarding ( this : * mut Foo , p : CRustForeignVec , ) -> ( ) {
  let mut p : Vec < Boo > = unsafe { Vec :: from_raw_parts ( p . data as * mut Boo , p . len , p . capacity ) } ;
  let this : & mut Foo = unsafe { this . as_mut ( ) . unwrap ( ) } ;
  let mut ret : ( ) = Foo :: set_alternate_boarding ( this , p ) ;

--- a/macroslib/tests/expectations/foreign_vec_return.cpp_rs
+++ b/macroslib/tests/expectations/foreign_vec_return.cpp_rs
@@ -1,10 +1,10 @@
-r##"# [ no_mangle ] pub extern "C" fn Boo_get_foo_arr ( this : * mut Boo , ) -> CRustForeignVec {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn Boo_get_foo_arr ( this : * mut Boo , ) -> CRustForeignVec {
  let this : & Boo = unsafe { this . as_mut ( ) . unwrap ( ) } ;
  let mut ret : Vec < Foo > = Boo :: get_foo_arr ( this , ) ;
  let mut ret : CRustForeignVec = CRustForeignVec :: from_vec ( ret ) ;
  ret }"##;
 
-r##"# [ no_mangle ] pub extern "C" fn Boo_get_foo_with_err ( this : * mut Boo , ) -> CRustResult4232mut3232c_voidCRustString {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn Boo_get_foo_with_err ( this : * mut Boo , ) -> CRustResult4232mut3232c_voidCRustString {
  let this : & Boo = unsafe { this . as_mut ( ) . unwrap ( ) } ;
  let mut ret : Result < Foo , String > = Boo :: get_foo_with_err ( this , ) ;
  let mut ret : CRustResult4232mut3232c_voidCRustString = match ret {
@@ -12,7 +12,7 @@ r##"# [ no_mangle ] pub extern "C" fn Boo_get_foo_with_err ( this : * mut Boo , 
  Err ( err ) => { let mut err : CRustString = CRustString :: from_string ( err ) ; CRustResult4232mut3232c_voidCRustString { data : CRustResultUnion4232mut3232c_voidCRustString { err } , is_ok : 0 , } } } ;
  ret }"##;
 
-r##"# [ no_mangle ] pub extern "C" fn Boo_get_foo_arr_with_err ( this : * mut Boo , ) -> CRustResultCRustForeignVecCRustString {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn Boo_get_foo_arr_with_err ( this : * mut Boo , ) -> CRustResultCRustForeignVecCRustString {
  let this : & Boo = unsafe { this . as_mut ( ) . unwrap ( ) } ;
  let mut ret : Result < Vec < Foo > , String > = Boo :: get_foo_arr_with_err ( this , ) ;
  let mut ret : CRustResultCRustForeignVecCRustString = match ret {

--- a/macroslib/tests/expectations/generic.java_rs
+++ b/macroslib/tests/expectations/generic.java_rs
@@ -1,4 +1,4 @@
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_example_Boo_do_1get_1foo_1arr(
     env: *mut JNIEnv,
     _: jclass,
@@ -11,7 +11,7 @@ pub extern "C" fn Java_org_example_Boo_do_1get_1foo_1arr(
     ret
 }"##;
 
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_example_Boo_do_1get_1one_1foo(
     env: *mut JNIEnv,
     _: jclass,
@@ -32,7 +32,7 @@ pub extern "C" fn Java_org_example_Boo_do_1get_1one_1foo(
     ret
 }"##;
 
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_example_Boo_r_1test_1u8(
     env: *mut JNIEnv,
     _: jclass,
@@ -54,7 +54,7 @@ pub extern "C" fn Java_org_example_Boo_r_1test_1u8(
     ret
 }"##;
 
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_example_Boo_do_1now(env: *mut JNIEnv, _: jclass) -> jlong {
     let mut ret: SystemTime = now();
     let since_unix_epoch = ret

--- a/macroslib/tests/expectations/inline_dyn.cpp_rs
+++ b/macroslib/tests/expectations/inline_dyn.cpp_rs
@@ -1,4 +1,4 @@
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn MapBitmapGenerator_already_rendered_bitmap(
     this: *mut Box<dyn MapBitmapGenerator>,
 ) -> CRustOption4232mut3232c_void {

--- a/macroslib/tests/expectations/inline_function.cpp_rs
+++ b/macroslib/tests/expectations/inline_function.cpp_rs
@@ -1,4 +1,4 @@
-r##"# [ no_mangle ]
+r##"# [ unsafe ( no_mangle ) ]
  pub extern "C" fn BLAUtils_latitude_to_str ( lat : CRustOptionf64 , plus_sym : CRustStrView , minus_sym : CRustStrView , ) -> CRustString {
  let mut lat : Option < f64 > = if lat . is_some != 0 { let mut ret = unsafe { lat . val . data } ; Some ( ret ) }
  else { None } ;
@@ -8,7 +8,7 @@ r##"# [ no_mangle ]
  let mut ret : CRustString = CRustString :: from_string ( ret ) ;
  ret }"##;
 
-r##"# [ no_mangle ]
+r##"# [ unsafe ( no_mangle ) ]
  pub extern "C" fn BLAUtils_longitude_to_str ( lon : CRustOptionf64 , plus_sym : CRustStrView , minus_sym : CRustStrView , ) -> CRustString {
  let mut lon : Option < f64 > = if lon . is_some != 0 { let mut ret = unsafe { lon . val . data } ; Some ( ret ) } else { None } ;
  let mut plus_sym : & str = unsafe { let slice : & [ u8 ] = :: std :: slice :: from_raw_parts ( plus_sym . data as * const u8 , plus_sym . len ) ; :: std :: str :: from_utf8_unchecked ( slice ) } ;

--- a/macroslib/tests/expectations/inline_function.java_rs
+++ b/macroslib/tests/expectations/inline_function.java_rs
@@ -1,4 +1,4 @@
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_example_BLAUtils_latitude_1to_1str(
     env: *mut JNIEnv,
     _: jclass,
@@ -21,7 +21,7 @@ pub extern "C" fn Java_org_example_BLAUtils_latitude_1to_1str(
     ret
 }"##;
 
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_example_BLAUtils_longitude_1to_1str(
     env: *mut JNIEnv,
     _: jclass,

--- a/macroslib/tests/expectations/lifetime_param_in_result.cpp_rs
+++ b/macroslib/tests/expectations/lifetime_param_in_result.cpp_rs
@@ -1,4 +1,4 @@
-r#"# [ no_mangle ] pub extern "C" fn Foo_f ( this : * mut RefCell < Foo >, a0 : i32 , ) -> ( ) {
+r#"# [ unsafe ( no_mangle ) ] pub extern "C" fn Foo_f ( this : * mut RefCell < Foo >, a0 : i32 , ) -> ( ) {
  let this : & RefCell < Foo > = unsafe { this . as_mut ( ) . unwrap ( ) } ;
  let mut this : Ref < Foo > = this.borrow();
  let mut this : & Foo = & this;

--- a/macroslib/tests/expectations/option_arg_cpp.cpp_rs
+++ b/macroslib/tests/expectations/option_arg_cpp.cpp_rs
@@ -1,4 +1,4 @@
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Foo_f4(this: *mut Foo, x: CRustOptionusize) -> () {
     let mut x: Option<usize> = if x.is_some != 0 {
         let mut ret = unsafe { x.val.data };
@@ -11,7 +11,7 @@ pub extern "C" fn Foo_f4(this: *mut Foo, x: CRustOptionusize) -> () {
     ret
 }"##;
 
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Foo_f5(x: CRustOptionf64, y: CRustOptionusize) -> () {
     let mut x: Option<f64> = if x.is_some != 0 {
         let mut ret = unsafe { x.val.data };
@@ -29,7 +29,7 @@ pub extern "C" fn Foo_f5(x: CRustOptionf64, y: CRustOptionusize) -> () {
     ret
 }"##;
 
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Foo_f6(x: CRustOptionCRustStrView) -> () {
     let mut x: Option<&str> = if x.is_some != 0 {
         let mut ret: &str = unsafe {
@@ -48,7 +48,7 @@ pub extern "C" fn Foo_f6(x: CRustOptionCRustStrView) -> () {
 }"##;
 
 
-r##"# [ no_mangle ] pub extern "C" fn Foo_f3 ( this : * mut Foo , a0 : CRustOptionu32 , ) -> ( ) {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn Foo_f3 ( this : * mut Foo , a0 : CRustOptionu32 , ) -> ( ) {
  let mut a0 : Option < ControlItem > = if a0 . is_some != 0 {
  let mut ret : ControlItem = < ControlItem >:: swig_from ( unsafe { a0 . val . data } ) ;
  Some ( ret ) } else { None } ;
@@ -56,7 +56,7 @@ r##"# [ no_mangle ] pub extern "C" fn Foo_f3 ( this : * mut Foo , a0 : CRustOpti
  let mut ret : ( ) = Foo :: f3 ( this , a0 ) ;
  ret }"##;
 
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Foo_f7(x: CRustClassOptBoo) -> () {
     let mut x: Option<&Boo> = if !x.p.is_null() {
         assert!(!x.p.is_null());

--- a/macroslib/tests/expectations/option_java.java_rs
+++ b/macroslib/tests/expectations/option_java.java_rs
@@ -1,4 +1,4 @@
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_example_Foo_do_1f7(
     env: *mut JNIEnv,
     _: jclass,

--- a/macroslib/tests/expectations/own_objects_creation.java_rs
+++ b/macroslib/tests/expectations/own_objects_creation.java_rs
@@ -1,4 +1,4 @@
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_example_Foo_init(env: *mut JNIEnv, _: jclass, a0: jint) -> jlong {
     let mut a0: i32 = a0;
     let this: Foo = Foo::new(a0);
@@ -7,7 +7,7 @@ pub extern "C" fn Java_org_example_Foo_init(env: *mut JNIEnv, _: jclass, a0: jin
     this as jlong
 }"##;
 
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_example_Foo_do_1f(
     env: *mut JNIEnv,
     _: jclass,
@@ -23,7 +23,7 @@ pub extern "C" fn Java_org_example_Foo_do_1f(
     ret
 }"##;
 
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_example_Boo_init(
     env: *mut JNIEnv,
     _: jclass,
@@ -47,7 +47,7 @@ pub extern "C" fn Java_org_example_Boo_init(
     this as jlong
 }"##;
 
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_example_Boo_do_1factory_1method(env: *mut JNIEnv, _: jclass) -> jlong {
     let mut ret: Result<Boo, String> = Boo::factory_method();
     let mut ret: jlong = match ret {
@@ -63,7 +63,7 @@ pub extern "C" fn Java_org_example_Boo_do_1factory_1method(env: *mut JNIEnv, _: 
     ret
 }"##;
 
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_example_Boo_do_1boo_1as_1arg(
     env: *mut JNIEnv,
     _: jclass,
@@ -79,7 +79,7 @@ pub extern "C" fn Java_org_example_Boo_do_1boo_1as_1arg(
     ret
 }"##;
 
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_example_Boo_do_1get_1one_1foo(
     env: *mut JNIEnv,
     _: jclass,

--- a/macroslib/tests/expectations/pass_objects_as_param.cpp_rs
+++ b/macroslib/tests/expectations/pass_objects_as_param.cpp_rs
@@ -1,4 +1,4 @@
-r##"# [ no_mangle ]
+r##"# [ unsafe ( no_mangle ) ]
  pub extern "C" fn TestPassObjectsAsParams_f1 ( this : * mut TestPassObjectsAsParams , a0 : * const :: std :: os :: raw :: c_void , ) -> ( ) {
  assert ! ( ! a0 . is_null ( ) ) ;
  let a0 : & RefCell < Foo > = unsafe { &* ( a0 as * const RefCell < Foo > ) } ;
@@ -6,7 +6,7 @@ r##"# [ no_mangle ]
  let mut ret : ( ) = TestPassObjectsAsParams :: f1 ( this , a0 ) ;
  ret }"##;
 
-r##"# [ no_mangle ]
+r##"# [ unsafe ( no_mangle ) ]
  pub extern "C" fn TestPassObjectsAsParams_f2 ( this : * mut TestPassObjectsAsParams , a0 : * mut :: std :: os :: raw :: c_void , ) -> ( ) {
  assert ! ( ! a0 . is_null ( ) ) ;
  let a0 : * mut RefCell < Foo > = a0 as * mut RefCell < Foo >;
@@ -15,7 +15,7 @@ r##"# [ no_mangle ]
  let mut ret : ( ) = TestPassObjectsAsParams :: f2 ( this , a0 ) ;
  ret }"##;
 
-r##"# [ no_mangle ]
+r##"# [ unsafe ( no_mangle ) ]
  pub extern "C" fn TestPassObjectsAsParams_f3 ( this : * mut TestPassObjectsAsParams , a0 : * mut :: std :: os :: raw :: c_void , ) -> ( ) {
  assert ! ( ! a0 . is_null ( ) ) ;
  let a0 : & mut RefCell < Foo > = unsafe { & mut * ( a0 as * mut RefCell < Foo > ) } ;
@@ -23,7 +23,7 @@ r##"# [ no_mangle ]
  let mut ret : ( ) = TestPassObjectsAsParams :: f3 ( this , a0 ) ;
  ret }"##;
 
-r##"# [ no_mangle ] pub extern "C" fn TestPassObjectsAsParams_f4 ( this : * mut TestPassObjectsAsParams , a0 : * const :: std :: os :: raw :: c_void , ) -> ( ) {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn TestPassObjectsAsParams_f4 ( this : * mut TestPassObjectsAsParams , a0 : * const :: std :: os :: raw :: c_void , ) -> ( ) {
  assert ! ( ! a0 . is_null ( ) ) ;
  let a0 : & RefCell < Foo > = unsafe { &* ( a0 as * const RefCell < Foo > ) } ;
  let mut a0 : Ref < Foo > = a0.borrow();
@@ -31,7 +31,7 @@ r##"# [ no_mangle ] pub extern "C" fn TestPassObjectsAsParams_f4 ( this : * mut 
  let this : & TestPassObjectsAsParams = unsafe { this . as_mut ( ) . unwrap ( ) } ;
  let mut ret : ( ) = TestPassObjectsAsParams :: f4 ( this , a0 ) ; ret }"##;
 
-r##"# [ no_mangle ] pub extern "C" fn TestPassObjectsAsParams_f5 ( this : * mut TestPassObjectsAsParams , a0 : * mut :: std :: os :: raw :: c_void , ) -> ( ) {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn TestPassObjectsAsParams_f5 ( this : * mut TestPassObjectsAsParams , a0 : * mut :: std :: os :: raw :: c_void , ) -> ( ) {
  assert ! ( ! a0 . is_null ( ) ) ;
  let a0 : & mut RefCell < Foo > = unsafe { & mut * ( a0 as * mut RefCell < Foo > ) } ;
  let mut a0 : & RefCell < Foo > = a0 ;

--- a/macroslib/tests/expectations/pass_objects_as_param.java_rs
+++ b/macroslib/tests/expectations/pass_objects_as_param.java_rs
@@ -1,4 +1,4 @@
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_example_TestPassObjectsAsParams_do_1f1(
     env: *mut JNIEnv,
     _: jclass,
@@ -15,7 +15,7 @@ pub extern "C" fn Java_org_example_TestPassObjectsAsParams_do_1f1(
     ret
 }"##;
 
-r#"#[no_mangle]
+r#"#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_example_TestPassObjectsAsParams_do_1f2(
     env: *mut JNIEnv,
     _: jclass,
@@ -33,7 +33,7 @@ pub extern "C" fn Java_org_example_TestPassObjectsAsParams_do_1f2(
     ret
 }"#;
 
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_example_TestPassObjectsAsParams_do_1f3(
     env: *mut JNIEnv,
     _: jclass,
@@ -65,7 +65,7 @@ r##"pub extern "C" fn Java_org_example_Foo_init(
     this as jlong
 }"##;
 
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_example_TestPassObjectsAsParams_do_1f4(
     env: *mut JNIEnv,
     _: jclass,
@@ -85,7 +85,7 @@ pub extern "C" fn Java_org_example_TestPassObjectsAsParams_do_1f4(
 }"##;
 
 
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_example_TestPassObjectsAsParams_do_1f5(
     env: *mut JNIEnv,
     _: jclass,

--- a/macroslib/tests/expectations/pass_objects_as_param_simple.cpp_rs
+++ b/macroslib/tests/expectations/pass_objects_as_param_simple.cpp_rs
@@ -1,4 +1,4 @@
-r##"# [ no_mangle ]
+r##"# [ unsafe ( no_mangle ) ]
  pub extern "C" fn TestPassObjectsAsParams_f1 ( this : * mut TestPassObjectsAsParams , a0 : * const :: std :: os :: raw :: c_void , ) -> ( ) {
  assert ! ( ! a0 . is_null ( ) ) ;
  let a0 : & Foo = unsafe { &* ( a0 as * const Foo ) } ;
@@ -7,7 +7,7 @@ r##"# [ no_mangle ]
  ret
  }"##;
 
-r##"# [ no_mangle ] pub extern "C" fn TestPassObjectsAsParams_f2 ( this : * mut TestPassObjectsAsParams , a0 : * mut :: std :: os :: raw :: c_void , ) -> ( ) {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn TestPassObjectsAsParams_f2 ( this : * mut TestPassObjectsAsParams , a0 : * mut :: std :: os :: raw :: c_void , ) -> ( ) {
  assert ! ( ! a0 . is_null ( ) ) ;
  let a0 : * mut Foo = a0 as * mut Foo ;
  let a0 : Box < Foo > = unsafe { Box :: from_raw ( a0 ) } ;
@@ -16,14 +16,14 @@ r##"# [ no_mangle ] pub extern "C" fn TestPassObjectsAsParams_f2 ( this : * mut 
  let mut ret : ( ) = TestPassObjectsAsParams :: f2 ( this , a0 ) ;
  ret }"##;
 
-r##"# [ no_mangle ]
+r##"# [ unsafe ( no_mangle ) ]
  pub extern "C" fn TestPassObjectsAsParams_f3 ( this : * mut TestPassObjectsAsParams , a0 : * mut :: std :: os :: raw :: c_void , ) -> ( ) {
  assert ! ( ! a0 . is_null ( ) ) ; let a0 : & mut Foo = unsafe { & mut * ( a0 as * mut Foo ) } ;
  let this : & TestPassObjectsAsParams = unsafe { this . as_mut ( ) . unwrap ( ) } ;
  let mut ret : ( ) = TestPassObjectsAsParams :: f3 ( this , a0 ) ;
  ret }"##;
 
-r##"# [ no_mangle ] pub extern "C" fn TestPassObjectsAsParams_f3_a ( this : * mut TestPassObjectsAsParams , a0 : * mut :: std :: os :: raw :: c_void , ) -> ( ) {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn TestPassObjectsAsParams_f3_a ( this : * mut TestPassObjectsAsParams , a0 : * mut :: std :: os :: raw :: c_void , ) -> ( ) {
  assert ! ( ! a0 . is_null ( ) ) ;
  let a0 : & mut Moo = unsafe { & mut * ( a0 as * mut Moo ) } ;
  let this : & TestPassObjectsAsParams = unsafe { this . as_mut ( ) . unwrap ( ) } ;
@@ -31,13 +31,13 @@ r##"# [ no_mangle ] pub extern "C" fn TestPassObjectsAsParams_f3_a ( this : * mu
  ret }"##;
 
 
-r##"# [ no_mangle ] pub extern "C" fn TestPassObjectsAsParams_f4 ( a0 : * const :: std :: os :: raw :: c_void , ) -> ( ) {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn TestPassObjectsAsParams_f4 ( a0 : * const :: std :: os :: raw :: c_void , ) -> ( ) {
  assert ! ( ! a0 . is_null ( ) ) ;
  let a0 : & Foo = unsafe { &* ( a0 as * const Foo ) } ;
  let mut ret : ( ) = TestPassObjectsAsParams :: f4 ( a0 ) ;
  ret }"##;
 
-r##"# [ no_mangle ] pub extern "C" fn TestPassObjectsAsParams_f5 ( a0 : * mut :: std :: os :: raw :: c_void , ) -> ( ) {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn TestPassObjectsAsParams_f5 ( a0 : * mut :: std :: os :: raw :: c_void , ) -> ( ) {
  assert ! ( ! a0 . is_null ( ) ) ;
  let a0 : * mut Foo = a0 as * mut Foo ;
  let a0 : Box < Foo > = unsafe { Box :: from_raw ( a0 ) } ;

--- a/macroslib/tests/expectations/pass_objects_as_param_simple.java_rs
+++ b/macroslib/tests/expectations/pass_objects_as_param_simple.java_rs
@@ -1,4 +1,4 @@
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_example_TestPassObjectsAsParams_do_1f1(
     env: *mut JNIEnv,
     _: jclass,
@@ -16,7 +16,7 @@ pub extern "C" fn Java_org_example_TestPassObjectsAsParams_do_1f1(
 }"##;
 
 
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_example_TestPassObjectsAsParams_do_1f2(
     env: *mut JNIEnv,
     _: jclass,
@@ -36,7 +36,7 @@ pub extern "C" fn Java_org_example_TestPassObjectsAsParams_do_1f2(
 }"##;
 
 
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_example_TestPassObjectsAsParams_do_1f3(
     env: *mut JNIEnv,
     _: jclass,
@@ -54,7 +54,7 @@ pub extern "C" fn Java_org_example_TestPassObjectsAsParams_do_1f3(
 }"##;
 
 
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_example_TestPassObjectsAsParams_do_1f3_1a(
     env: *mut JNIEnv,
     _: jclass,
@@ -72,7 +72,7 @@ pub extern "C" fn Java_org_example_TestPassObjectsAsParams_do_1f3_1a(
 }"##;
 
 
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_example_TestPassObjectsAsParams_do_1f4(
     env: *mut JNIEnv,
     _: jclass,
@@ -84,7 +84,7 @@ pub extern "C" fn Java_org_example_TestPassObjectsAsParams_do_1f4(
 }"##;
 
 
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_example_TestPassObjectsAsParams_do_1f5(
     env: *mut JNIEnv,
     _: jclass,

--- a/macroslib/tests/expectations/pass_slice_as_args.cpp_rs
+++ b/macroslib/tests/expectations/pass_slice_as_args.cpp_rs
@@ -1,11 +1,11 @@
-r##"# [ no_mangle ] pub extern "C" fn Boo_f1 ( this : * mut Boo , a0 : CRustObjectMutSlice , ) -> CRustSliceu32 {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn Boo_f1 ( this : * mut Boo , a0 : CRustObjectMutSlice , ) -> CRustSliceu32 {
  let mut a0 : & mut [ Foo ] = unsafe { :: std :: slice :: from_raw_parts_mut ( a0 . data as * mut Foo , a0 . len ) } ;
  let this : & Boo = unsafe { this . as_mut ( ) . unwrap ( ) } ;
  let mut ret : & [ u32 ] = Boo :: f1 ( this , a0 ) ;
  let mut ret : CRustSliceu32 = CRustSliceu32 { data : ret . as_ptr ( ) , len : ret . len ( ) , } ;
  ret }"##;
 
-r##"# [ no_mangle ] pub extern "C" fn Boo_f2 ( this : * mut Boo , a0 : CRustObjectSlice , ) -> CRustSliceu32 {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn Boo_f2 ( this : * mut Boo , a0 : CRustObjectSlice , ) -> CRustSliceu32 {
  let mut a0 : & [ Foo ] = unsafe { :: std :: slice :: from_raw_parts ( a0 . data as * const Foo , a0 . len ) } ;
  let this : & Boo = unsafe { this . as_mut ( ) . unwrap ( ) } ;
  let mut ret : & [ u32 ] = Boo :: f2 ( this , a0 ) ;

--- a/macroslib/tests/expectations/reachability_fence_java.java_rs
+++ b/macroslib/tests/expectations/reachability_fence_java.java_rs
@@ -1,4 +1,4 @@
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_example_JNIReachabilityFence_reachabilityFence1(
     _env: *mut JNIEnv,
     _: jclass,

--- a/macroslib/tests/expectations/references.cpp_rs
+++ b/macroslib/tests/expectations/references.cpp_rs
@@ -1,17 +1,17 @@
-r##"# [ no_mangle ] pub extern "C" fn TestReferences_get_foo_ref ( this : * mut TestReferences , ) -> * const :: std :: os :: raw :: c_void {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn TestReferences_get_foo_ref ( this : * mut TestReferences , ) -> * const :: std :: os :: raw :: c_void {
  let this : & TestReferences = unsafe { this . as_mut ( ) . unwrap ( ) } ;
  let mut ret : & Foo = TestReferences :: get_foo_ref ( this , ) ;
  let ret : * const :: std :: os :: raw :: c_void = ( ret as * const Foo ) as * const :: std :: os :: raw :: c_void ;
  ret }"##;
 
-r##"# [ no_mangle ] pub extern "C" fn TestReferences_update_foo ( this : * mut TestReferences , foo : * const :: std :: os :: raw :: c_void , ) -> ( ) {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn TestReferences_update_foo ( this : * mut TestReferences , foo : * const :: std :: os :: raw :: c_void , ) -> ( ) {
  assert ! ( ! foo . is_null ( ) ) ;
  let foo : & Foo = unsafe { &* ( foo as * const Foo ) } ;
  let this : & mut TestReferences = unsafe { this . as_mut ( ) . unwrap ( ) } ;
  let mut ret : ( ) = TestReferences :: update_foo ( this , foo ) ;
  ret }"##;
 
-r##"# [ no_mangle ] pub extern "C" fn TestReferences_update_mut_foo ( this : * mut TestReferences , foo : * mut :: std :: os :: raw :: c_void , ) -> ( ) {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn TestReferences_update_mut_foo ( this : * mut TestReferences , foo : * mut :: std :: os :: raw :: c_void , ) -> ( ) {
  assert ! ( ! foo . is_null ( ) ) ;
  let foo : & mut Foo = unsafe { & mut * ( foo as * mut Foo ) } ;
  let this : & mut TestReferences = unsafe { this . as_mut ( ) . unwrap ( ) } ;

--- a/macroslib/tests/expectations/return_foreign_class2.java_rs
+++ b/macroslib/tests/expectations/return_foreign_class2.java_rs
@@ -1,4 +1,4 @@
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_example_Moo_do_1getBoo(
     env: *mut JNIEnv,
     _: jclass,

--- a/macroslib/tests/expectations/return_foreign_class_arc.java_rs
+++ b/macroslib/tests/expectations/return_foreign_class_arc.java_rs
@@ -1,4 +1,4 @@
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_example_Moo_do_1getBoo(
     env: *mut JNIEnv,
     _: jclass,
@@ -11,7 +11,7 @@ pub extern "C" fn Java_org_example_Moo_do_1getBoo(
 }"##;
 
 r##"#[allow(non_snake_case, unused_variables, unused_mut, unused_unsafe)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_example_Boo_do_1test(
     env: *mut JNIEnv,
     _: jclass,

--- a/macroslib/tests/expectations/return_foreign_enum_as_err.cpp_rs
+++ b/macroslib/tests/expectations/return_foreign_enum_as_err.cpp_rs
@@ -1,4 +1,4 @@
-r##"# [ no_mangle ] pub extern "C" fn Boo_f ( this : * mut Boo , ) -> CRustResult4232mut3232c_voidu32 {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn Boo_f ( this : * mut Boo , ) -> CRustResult4232mut3232c_voidu32 {
  let this : & Boo = unsafe { this . as_mut ( ) . unwrap ( ) } ;
  let mut ret : Result < Moo , Foo > = Boo :: f ( this , ) ;
  let mut ret : CRustResult4232mut3232c_voidu32 = match ret { Ok ( mut x ) => {
@@ -8,7 +8,7 @@ r##"# [ no_mangle ] pub extern "C" fn Boo_f ( this : * mut Boo , ) -> CRustResul
    CRustResult4232mut3232c_voidu32 { data : CRustResultUnion4232mut3232c_voidu32 { err } , is_ok : 0 , } } } ;
  ret }"##;
 
-r#"# [ no_mangle ] pub extern "C" fn Boo_f2 ( this : * mut Boo , a0 : u32 , ) -> u32 {
+r#"# [ unsafe ( no_mangle ) ] pub extern "C" fn Boo_f2 ( this : * mut Boo , a0 : u32 , ) -> u32 {
  let mut a0 : Foo = < Foo >:: swig_from ( a0 ) ;
  let this : & Boo = unsafe { this . as_mut ( ) . unwrap ( ) } ;
  let mut ret : Foo = Boo :: f2 ( this , a0 ) ;

--- a/macroslib/tests/expectations/return_foreign_interface_opt.cpp_rs
+++ b/macroslib/tests/expectations/return_foreign_interface_opt.cpp_rs
@@ -1,4 +1,4 @@
-r##"# [ no_mangle ] pub extern "C" fn Boo_f2 ( this : * mut Boo , ) -> CRustOption4232mut3232c_void {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn Boo_f2 ( this : * mut Boo , ) -> CRustOption4232mut3232c_void {
  let this : & mut Boo = unsafe { this . as_mut ( ) . unwrap ( ) } ;
  let mut ret : Option < Box < Box < Foo > > > = Boo :: f2 ( this , ) ;
  let mut ret : CRustOption4232mut3232c_void = match ret { Some ( mut x ) => {

--- a/macroslib/tests/expectations/return_slice.cpp_rs
+++ b/macroslib/tests/expectations/return_slice.cpp_rs
@@ -1,22 +1,22 @@
-r##"# [ no_mangle ] pub extern "C" fn Boo_f1 ( this : * mut Boo , ) -> CRustSliceu32 {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn Boo_f1 ( this : * mut Boo , ) -> CRustSliceu32 {
  let this : & Boo = unsafe { this . as_mut ( ) . unwrap ( ) } ;
  let mut ret : & [ u32 ] = Boo :: f1 ( this , ) ;
  let mut ret : CRustSliceu32 = CRustSliceu32 { data : ret . as_ptr ( ) , len : ret . len ( ) , } ;
  ret }"##;
 
-r##"# [ no_mangle ] pub extern "C" fn Boo_f2 ( this : * mut Boo , ) -> CRustObjectSlice {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn Boo_f2 ( this : * mut Boo , ) -> CRustObjectSlice {
  let this : & Boo = unsafe { this . as_mut ( ) . unwrap ( ) } ;
  let mut ret : & [ Foo ] = Boo :: f2 ( this , ) ;
  let mut ret : CRustObjectSlice = CRustObjectSlice { data : ret . as_ptr ( ) as * const :: std :: os :: raw :: c_void , len : ret . len ( ) , step : :: std :: mem :: size_of ::< Foo > ( ) , } ;
  ret }"##;
 
-r##"# [ no_mangle ] pub extern "C" fn Boo_f3 ( this : * mut Boo , ) -> CRustSliceusize {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn Boo_f3 ( this : * mut Boo , ) -> CRustSliceusize {
  let this : & Boo = unsafe { this . as_mut ( ) . unwrap ( ) } ;
  let mut ret : & [ usize ] = Boo :: f3 ( this , ) ;
  let mut ret : CRustSliceusize = CRustSliceusize { data : ret . as_ptr ( ) , len : ret . len ( ) , } ;
  ret }"##;
 
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Boo_f4(this: *mut Boo) -> CRustSliceMutusize {
     let this: &Boo = unsafe { this.as_mut().unwrap() };
     let mut ret: &mut [usize] = Boo::f4(this);

--- a/macroslib/tests/expectations/smart_ptr_copy_derived.java_rs
+++ b/macroslib/tests/expectations/smart_ptr_copy_derived.java_rs
@@ -1,4 +1,4 @@
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_example_NavigationService_do_1subscribeOnUpdates(
     env: *mut JNIEnv,
     _: jclass,
@@ -26,7 +26,7 @@ pub extern "C" fn Java_org_example_NavigationService_do_1subscribeOnUpdates(
     ret
 }"##;
 
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_example_Session_do_1setFoo(
     env: *mut JNIEnv,
     _: jclass,

--- a/macroslib/tests/expectations/smart_ptr_copy_derived_arc.java_rs
+++ b/macroslib/tests/expectations/smart_ptr_copy_derived_arc.java_rs
@@ -1,4 +1,4 @@
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_example_NavigationService_do_1subscribeOnUpdates(
     env: *mut JNIEnv,
     _: jclass,
@@ -26,7 +26,7 @@ pub extern "C" fn Java_org_example_NavigationService_do_1subscribeOnUpdates(
     ret
 }"##;
 
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_example_Session_do_1setFoo(
     env: *mut JNIEnv,
     _: jclass,

--- a/macroslib/tests/expectations/static_func_with_foreign_class_as_param1.cpp_rs
+++ b/macroslib/tests/expectations/static_func_with_foreign_class_as_param1.cpp_rs
@@ -1,4 +1,4 @@
-r##"# [ no_mangle ] pub extern "C" fn Foo_static_foo ( a0 : * const :: std :: os :: raw :: c_void , ) -> ( ) {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn Foo_static_foo ( a0 : * const :: std :: os :: raw :: c_void , ) -> ( ) {
  assert ! ( ! a0 . is_null ( ) ) ;
  let a0 : & RefCell < Boo > = unsafe { &* ( a0 as * const RefCell < Boo > ) } ;
  let mut a0 : Ref < Boo > = a0.borrow();

--- a/macroslib/tests/expectations/static_func_with_foreign_class_as_param1.java_rs
+++ b/macroslib/tests/expectations/static_func_with_foreign_class_as_param1.java_rs
@@ -1,4 +1,4 @@
-r##"# [ no_mangle ] pub extern "C" fn Java_org_example_Foo_do_1static_1foo ( env : * mut JNIEnv , _ : jclass , a0 : jlong , ) -> ( ) {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn Java_org_example_Foo_do_1static_1foo ( env : * mut JNIEnv , _ : jclass , a0 : jlong , ) -> ( ) {
  let a0 : & RefCell < Boo > = unsafe { jlong_to_pointer ::< RefCell < Boo >> ( a0 ) . as_mut ( ) . unwrap ( ) } ;
  let mut a0 : Ref < Boo > = a0.borrow();
  let mut a0 : & Boo = &a0;

--- a/macroslib/tests/expectations/static_func_with_foreign_class_full.cpp_rs
+++ b/macroslib/tests/expectations/static_func_with_foreign_class_full.cpp_rs
@@ -1,22 +1,22 @@
-r##"# [ no_mangle ] pub extern "C" fn Boo_boo_init ( ) -> * const :: std :: os :: raw :: c_void {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn Boo_boo_init ( ) -> * const :: std :: os :: raw :: c_void {
  let this : Rc < RefCell < Boo > > = boo_init ( ) ;
  let this : * const RefCell < Boo > = Rc :: into_raw ( this ) ;
  this as * const :: std :: os :: raw :: c_void
  }"##;
 
-r##"# [ no_mangle ] pub extern "C" fn Boo_f1 ( this : * mut RefCell < Boo >, ) -> ( ) {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn Boo_f1 ( this : * mut RefCell < Boo >, ) -> ( ) {
  let this : & RefCell < Boo > = unsafe { this . as_mut ( ) . unwrap ( ) } ;
  let mut this : Ref < Boo > = this.borrow();
  let mut this : & Boo = & this;
  let mut ret : ( ) = Boo :: f1 ( this , ) ;
  ret }"##;
 
-r##"# [ no_mangle ] pub extern "C" fn Boo_delete ( this : * mut RefCell < Boo > ) {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn Boo_delete ( this : * mut RefCell < Boo > ) {
  let this : Rc < RefCell < Boo > > = unsafe { Rc :: from_raw ( this ) } ;
  drop ( this ) ;
  }"##;
 
-r##"# [ no_mangle ] pub extern "C" fn Foo_f1 ( a0 : * const :: std :: os :: raw :: c_void , ) -> ( ) {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn Foo_f1 ( a0 : * const :: std :: os :: raw :: c_void , ) -> ( ) {
  assert ! ( ! a0 . is_null ( ) ) ;
  let a0 : & RefCell < Boo > = unsafe { &* ( a0 as * const RefCell < Boo > ) } ;
  let mut a0 : Ref < Boo > = a0.borrow();
@@ -24,7 +24,7 @@ r##"# [ no_mangle ] pub extern "C" fn Foo_f1 ( a0 : * const :: std :: os :: raw 
  let mut ret : ( ) = f1 ( a0 ) ;
  ret }"##;
 
-r##"# [ no_mangle ] pub extern "C" fn Foo_f2 ( a0 : * mut :: std :: os :: raw :: c_void , ) -> ( ) {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn Foo_f2 ( a0 : * mut :: std :: os :: raw :: c_void , ) -> ( ) {
  assert ! ( ! a0 . is_null ( ) ) ;
  let a0 : & mut RefCell < Boo > = unsafe { & mut * ( a0 as * mut RefCell < Boo > ) } ;
  let mut a0 : & RefCell < Boo > = a0 ;

--- a/macroslib/tests/expectations/static_func_with_foreign_class_full.java_rs
+++ b/macroslib/tests/expectations/static_func_with_foreign_class_full.java_rs
@@ -1,17 +1,17 @@
-r##"# [ no_mangle ] pub extern "C" fn Java_org_example_Boo_do_1f1 ( env : * mut JNIEnv , _ : jclass , this : jlong , ) -> ( ) {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn Java_org_example_Boo_do_1f1 ( env : * mut JNIEnv , _ : jclass , this : jlong , ) -> ( ) {
  let this : & RefCell < Boo > = unsafe { jlong_to_pointer ::< RefCell < Boo >> ( this ) . as_mut ( ) . unwrap ( ) } ;
  let mut this : Ref < Boo > = this.borrow();
  let mut this : & Boo = & this;
  let mut ret : ( ) = Boo :: f1 ( this , ) ;
  ret }"##;
 
-r##"# [ no_mangle ] pub extern "C" fn Java_org_example_Foo_do_1f1 ( env : * mut JNIEnv , _ : jclass , a0 : jlong , ) -> ( ) {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn Java_org_example_Foo_do_1f1 ( env : * mut JNIEnv , _ : jclass , a0 : jlong , ) -> ( ) {
  let a0 : & RefCell < Boo > = unsafe { jlong_to_pointer ::< RefCell < Boo >> ( a0 ) . as_mut ( ) . unwrap ( ) } ;
  let mut a0 : Ref < Boo > = a0.borrow();
  let mut a0 : & Boo = & a0;
  let mut ret : ( ) = f1 ( a0 ) ; ret }"##;
 
-r##"# [ no_mangle ] pub extern "C" fn Java_org_example_Foo_do_1f2 ( env : * mut JNIEnv , _ : jclass , a0 : jlong , ) -> ( ) {
+r##"# [ unsafe ( no_mangle ) ] pub extern "C" fn Java_org_example_Foo_do_1f2 ( env : * mut JNIEnv , _ : jclass , a0 : jlong , ) -> ( ) {
  let a0 : & RefCell < Boo > = unsafe { jlong_to_pointer ::< RefCell < Boo >> ( a0 ) . as_mut ( ) . unwrap ( ) } ;
  let mut a0 : RefMut < Boo > = a0.borrow_mut();
  let mut a0 : & mut Boo = &mut a0;

--- a/macroslib/tests/expectations/string_handling.cpp_rs
+++ b/macroslib/tests/expectations/string_handling.cpp_rs
@@ -1,4 +1,4 @@
-r##"#[no_mangle]
+r##"#[unsafe(no_mangle)]
 pub extern "C" fn Foo_f(this: *mut Foo, a0: i32, a1: i32, a2: CRustStrView) -> CRustString {
     let mut a2: &str = unsafe {
         let slice: &[u8] = ::std::slice::from_raw_parts(a2.data as *const u8, a2.len);

--- a/macroslib/tests/expectations/test_bare_fn_match.cpp_rs
+++ b/macroslib/tests/expectations/test_bare_fn_match.cpp_rs
@@ -1,4 +1,4 @@
-r##"# [ no_mangle ]
+r##"# [ unsafe ( no_mangle ) ]
  pub extern "C" fn TestFuture_call_fn ( f : CFnOncei32 , ) -> ( ) {
  let mut f = | x | { ; f . cb ( x , f . ctx ) ; } ;
  let mut ret : ( ) = { f ( 5 ) ; } ;


### PR DESCRIPTION
Rust edition 2024 does no longer allow #[no_mangle]. See https://doc.rust-lang.org/stable/edition-guide/rust-2024/unsafe-attributes.html

