### PR TITLE
CI: migrate from actions-rs/toolchain@v1 to dtolnay/rust-toolchain@v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,14 +70,11 @@ jobs:
         run: Rename-Item C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc.old
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: hecrj/setup-rust-action@v2
         with:
-          toolchain: ${{ matrix.rust }}
-          profile: minimal
-          target: ${{ matrix.target }}
-          override: true
+          rust-version: ${{ matrix.rust }}
+          targets: ${{ matrix.target }}
           components: rustfmt
-          default: true
       - uses: actions/setup-python@v5
         with:
           python-version: '3.7.8'
@@ -203,12 +200,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions-rs/toolchain@v1
+      - uses: hecrj/setup-rust-action@v2
         with:
-          profile: minimal
           # Docs.rs uses nightly, which allows for easier syntax for linking to functions.
-          toolchain: nightly
-          override: true
+          rust-version: nightly
       - name: cargo rustdoc
         run: |
           set -e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
           components: rustfmt
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.7.13'
+          python-version: '3.8.0'
           architecture: ${{ matrix.platform || 'x64' }}
       - uses: jwlawson/actions-setup-cmake@v1.4
         if: matrix.os != 'windows-2019'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,9 +70,9 @@ jobs:
         run: Rename-Item C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc.old
 
       - name: Install Rust toolchain
-        uses: hecrj/setup-rust-action@v2
+        uses: dtolnay/rust-toolchain@v1
         with:
-          rust-version: ${{ matrix.rust }}
+          toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
           components: rustfmt
       - uses: actions/setup-python@v5
@@ -200,10 +200,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: hecrj/setup-rust-action@v2
+      - uses: dtolnay/rust-toolchain@v1
         with:
           # Docs.rs uses nightly, which allows for easier syntax for linking to functions.
-          rust-version: nightly
+          toolchain: nightly
       - name: cargo rustdoc
         run: |
           set -e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,12 @@ jobs:
             target: x86_64-pc-windows-msvc
             platform: x64
           - name: x86_64-unknown-linux-gnu (stable)
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             rust: stable
             target: x86_64-unknown-linux-gnu
 
           - name: x86_64-unknown-linux-gnu (beta)
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             rust: beta
             target: x86_64-unknown-linux-gnu
 
@@ -77,7 +77,7 @@ jobs:
           components: rustfmt
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.7.8'
+          python-version: '3.7.13'
           architecture: ${{ matrix.platform || 'x64' }}
       - uses: jwlawson/actions-setup-cmake@v1.4
         if: matrix.os != 'windows-2019'
@@ -91,7 +91,7 @@ jobs:
           cmake-version: '3.14.7'
           github-api-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Choose boost version (not ubuntu)
-        if: matrix.os != 'ubuntu-20.04'
+        if: matrix.os != 'ubuntu-22.04'
         run: |
           echo 'BOOST_VER=1.66.0'  >> $GITHUB_ENV
         shell: bash
@@ -99,7 +99,7 @@ jobs:
       # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80635
       # use the lastest boost to work around this bug
       - name: Choose boost version (ubuntu)
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           echo 'BOOST_VER=1.73.0'  >> $GITHUB_ENV
         shell: bash
@@ -113,7 +113,7 @@ jobs:
           echo "BOOST_ROOT=$PWD/boost_$BOOST_VER_NAME" >> $GITHUB_ENV
         shell: bash
       - name: Install valgrind for linux
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-22.04'
         run: sudo apt-get -y update && sudo apt-get install -y valgrind
       - name: Install llvm tools on Windows
         if: matrix.os == 'windows-2019'
@@ -142,7 +142,7 @@ jobs:
           echo "SCCACHE_BUCKET=flapigenamd64win" >> $GITHUB_ENV
         shell: bash
       - name: install sccache (linux)
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           set -e
           curl -L https://github.com/mozilla/sccache/releases/download/$SCCACHE_VER/sccache-$SCCACHE_VER-x86_64-unknown-linux-musl.tar.gz -o sccache.tar.gz
@@ -196,7 +196,7 @@ jobs:
           CARGO_BUILD_TARGET: ${{ matrix.target }}
   doc_tests:
     name: Docs (Detect cases where documentation links don't resolve and such)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,14 @@ jobs:
           targets: ${{ matrix.target }}
           components: rustfmt
       - uses: actions/setup-python@v5
+        if: matrix.os == 'windows-2019'
         with:
           python-version: '3.8.0'
+          architecture: ${{ matrix.platform || 'x64' }}
+      - uses: actions/setup-python@v5
+        if: matrix.os != 'windows-2019'
+        with:
+          python-version: '3.7.13'
           architecture: ${{ matrix.platform || 'x64' }}
       - uses: jwlawson/actions-setup-cmake@v1.4
         if: matrix.os != 'windows-2019'

--- a/ci_build_and_test.py
+++ b/ci_build_and_test.py
@@ -214,10 +214,10 @@ def test_python(is_windows: bool, test_cfg: Set[str]):
         if is_windows:
             shutil.copyfile(os.path.join(target_dir, "flapigen_test_python.dll"), "python_tests/python/flapigen_test_python.pyd")
             if os.getenv('platform') == "x64":
-                subprocess.check_call(["py", "-3.7-64", "main.py"], cwd = "python_tests/python")
+                subprocess.check_call(["py", "-3.8-64", "main.py"], cwd = "python_tests/python")
             else:
                 # If we choose 32, we must also choose specific, minor python version.
-                subprocess.check_call(["py", "-3.7-32", "main.py"], cwd = "python_tests/python")
+                subprocess.check_call(["py", "-3.8-32", "main.py"], cwd = "python_tests/python")
         else:
             lib_name = "libflapigen_test_python.dylib" if sys.platform == "darwin" else "libflapigen_test_python.so"
             shutil.copyfile(os.path.join(target_dir, lib_name), "python_tests/python/flapigen_test_python.so")


### PR DESCRIPTION
CI build is broken because of actions-rs/toolchain@v1, looks like actions-rs/toolchain@v1 is deprecated (it's repo is readonly)